### PR TITLE
Fix: add correct import in `Quick Start` topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## 🛠️ Quick Start
 
 ```kotlin
-import monke.trees
+import monke.trees.BSTree
 
 fun main() {
 


### PR DESCRIPTION
Fix import in `Quick Start` topic